### PR TITLE
fixed recursion bug

### DIFF
--- a/src/main/java/dev/cammiescorner/cammiesminecarttweaks/mixin/AbstractMinecartEntityMixin.java
+++ b/src/main/java/dev/cammiescorner/cammiesminecarttweaks/mixin/AbstractMinecartEntityMixin.java
@@ -177,7 +177,7 @@ public abstract class AbstractMinecartEntityMixin extends Entity implements Link
 							Set<Linkable> train = new HashSet<>();
 							train.add(linkable);
 
-							while((linkable = (Linkable) linkable.getLinkedParent()) instanceof Linkable) {
+							while((linkable = (Linkable) linkable.getLinkedParent()) instanceof Linkable && !train.contains(linkable)) {
 								train.add(linkable);
 							}
 

--- a/src/main/java/dev/cammiescorner/cammiesminecarttweaks/mixin/FurnaceMinecartEntityMixin.java
+++ b/src/main/java/dev/cammiescorner/cammiesminecarttweaks/mixin/FurnaceMinecartEntityMixin.java
@@ -85,7 +85,7 @@ public abstract class FurnaceMinecartEntityMixin extends AbstractMinecartEntity 
 			Set<Linkable> train = new HashSet<>();
 			train.add(linkable);
 
-			while((linkable = (Linkable) linkable.getLinkedChild()) instanceof Linkable) {
+			while((linkable = (Linkable) linkable.getLinkedChild()) instanceof Linkable && !train.contains(linkable)) {
 				train.add(linkable);
 			}
 


### PR DESCRIPTION
love the mod, great work! found a small bug to squash :3

added a check when assembling trains to break if a linkable is already in the train list. this fixes a recursion based crash where when joining two different direction trains together the game would hang until interrupted by watchdog (server) or killed (client).